### PR TITLE
Remove unneeded curl installation during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
-      - run: apt-get update
-      - run: apt-get install -y curl
       - checkout
       - run: bash .ci-scripts/install-dependencies.bash
       - run: stable fetch
@@ -21,8 +19,6 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
-      - run: apt-get update
-      - run: apt-get install -y curl
       - checkout
       - run: bash .ci-scripts/install-dependencies.bash
       - run: stable fetch


### PR DESCRIPTION
curl is now already available in the release image. We don't need
to install it.

Closes #4