### PR TITLE
Run the breakage test against a ponyc that still moves

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:latest
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-pcre:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
The workflow exists to find out about a ponyc change before it lands in a release, and it posts to Zulip when it fails. It was using `shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:latest`, an image shared-docker stopped rebuilding on 2025-10-20 when [#111](https://github.com/ponylang/shared-docker/pull/111) renamed it and moved it off the `latest` tag. The old name kept resolving, so nothing failed — the workflow just kept building against the ponyc of that day.

`shared-docker-ci-standard-builder-with-pcre:nightly` is the replacement, built from ponyc main.

Closes #70