### PR TITLE
Add pony-lint CI workflow

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -47,6 +48,10 @@ $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) |
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o $(BUILD_DIR) $(EXAMPLES_DIR)/$*
 
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) $(SRC_DIR) $(EXAMPLES_DIR)
+
 clean:
 	$(CLEAN_DEPENDENCIES_WITH)
 	rm -rf $(BUILD_DIR)
@@ -66,4 +71,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all build-examples clean TAGS test test-one
+.PHONY: all build-examples clean lint TAGS test test-one

--- a/examples/simple-example/main.pony
+++ b/examples/simple-example/main.pony
@@ -1,0 +1,9 @@
+// in your code this `use` statement would be:
+// use "glob"
+use "../../glob"
+
+actor Main
+  new create(env: Env) =>
+    env.out.print(
+      "we need at least 1 example. this one does nothing yet. "
+        + "want to contribute one?")

--- a/examples/simple-example/simple-example.pony
+++ b/examples/simple-example/simple-example.pony
@@ -1,7 +1,0 @@
-// in your code this `use` statement would be:
-// use "glob"
-use "../../glob"
-
-actor Main
-  new create(env: Env) =>
-    env.out.print("we need at least 1 example. this one does nothing yet. want to contribute one?")

--- a/examples/simple-example/simple_example.pony
+++ b/examples/simple-example/simple_example.pony
@@ -1,0 +1,3 @@
+"""
+Simple example demonstrating basic glob usage.
+"""

--- a/glob/_test.pony
+++ b/glob/_test.pony
@@ -52,9 +52,10 @@ actor \nodoc\ Main is TestList
     test(_TestFnMatch("a12c", "a[12]c", false))
 
 primitive \nodoc\ _FileHelper
-  fun make_files(h: TestHelper, files: Array[String]): FilePath? =>
-    let top = Directory(
-      FilePath.mkdtemp(FileAuth(h.env.root), "tmp._FileHelper.")?)?
+  fun make_files(h: TestHelper, files: Array[String]): FilePath ? =>
+    let top =
+      Directory(
+        FilePath.mkdtemp(FileAuth(h.env.root), "tmp._FileHelper.")?)?
     for f in files.values() do
       try
         let dir_head = Path.split(f)
@@ -111,7 +112,7 @@ class \nodoc\ iso _TestFilter is UnitTest
 class \nodoc\ iso _TestGlob is UnitTest
   fun name(): String => "files/FilePath.glob"
 
-  fun _rel(top: FilePath, files: Array[FilePath]): Array[String]? =>
+  fun _rel(top: FilePath, files: Array[FilePath]): Array[String] ? =>
     let res = recover ref Array[String] end
     for fp in files.values() do
       res.push(Path.rel(top.path, fp.path)?)
@@ -140,14 +141,22 @@ class \nodoc\ iso _TestIGlob is UnitTest
     res
 
   fun apply(h: TestHelper) ? =>
-    let top = _FileHelper.make_files(h, ["a/1"; "a/2"; "b"; "c/1"; "c/4"])?
+    let top =
+      _FileHelper.make_files(
+        h, ["a/1"; "a/2"; "b"; "c/1"; "c/4"])?
     try
-      Glob.iglob(top, "*/1",
+      Glob.iglob(
+        top,
+        "*/1",
         {(f: FilePath, matches: Array[String]) =>
           try
             match matches(0)?
-            | "a" => h.assert_eq[String](Path.rel(top.path, f.path)?, "a/1")
-            | "c" => h.assert_eq[String](Path.rel(top.path, f.path)?, "c/1")
+            | "a" =>
+              h.assert_eq[String](
+                Path.rel(top.path, f.path)?, "a/1")
+            | "c" =>
+              h.assert_eq[String](
+                Path.rel(top.path, f.path)?, "c/1")
             else error
             end
           else

--- a/glob/glob.pony
+++ b/glob/glob.pony
@@ -10,14 +10,6 @@ See `primitive Glob` for additional usage details.
 use "files"
 use "regex"
 
-interface GlobHandler
-  """
-  A handler for `Glob.iglob`. Each path which matches the glob will be called
-  with the groups that matched the various wildcards supplies in the
-  `match_groups` array.
-  """
-  fun ref apply(path: FilePath, match_groups: Array[String])
-
 primitive Glob
   """
   Filename matching and globbing with shell patterns.
@@ -49,7 +41,9 @@ primitive Glob
     fnmatchcase(Path.normcase(name), Path.normcase(pattern))
 
   fun fnmatchcase(name: String, pattern: String): Bool =>
-    """Tests whether `name` matches `pattern`, including case."""
+    """
+    Tests whether `name` matches `pattern`, including case.
+    """
     try
       Regex(translate(pattern))? == name
     else
@@ -122,7 +116,8 @@ primitive Glob
               res.append("\\^")
               i = i + 1
             end
-            let sub = recover ref pat.substring(i.isize(), j.isize()) end
+            let sub =
+              recover ref pat.substring(i.isize(), j.isize()) end
             res.append(sub .> replace("\\","\\\\"))
             res.append("])")
             i = j + 1
@@ -148,7 +143,7 @@ primitive Glob
     on `Glob` for details.
     """
     let res = Array[FilePath]
-    iglob(root_path, pattern, {(path, _) => res.push(path)})
+    iglob(root_path, pattern, {(path, _) => res.push(path) })
     res
 
   fun _apply_glob_to_walk(
@@ -162,12 +157,13 @@ primitive Glob
     for e in entries.values() do
       try
         let p = dir.join(e)?
-        let m = compiled_pattern(
-          if Path.is_abs(pattern) then
-            p.path
-          else
-            Path.rel(root.path, p.path)?
-          end)?
+        let m =
+          compiled_pattern(
+            if Path.is_abs(pattern) then
+              p.path
+            else
+              Path.rel(root.path, p.path)?
+            end)?
         glob_handler(p, m.groups())
       end
     end
@@ -184,5 +180,8 @@ primitive Glob
     // not contain wildcards and expanding them before walking.
     try
       root.walk(this~_apply_glob_to_walk(
-        pattern, Regex(translate(Path.normcase(pattern)))?, root, glob_handler))
+        pattern,
+        Regex(translate(Path.normcase(pattern)))?,
+        root,
+        glob_handler))
     end

--- a/glob/glob_handler.pony
+++ b/glob/glob_handler.pony
@@ -1,0 +1,13 @@
+use "files"
+
+interface GlobHandler
+  """
+  A handler for `Glob.iglob`. Each path which matches the glob will be called
+  with the groups that matched the various wildcards supplies in the
+  `match_groups` array.
+  """
+
+  fun ref apply(path: FilePath, match_groups: Array[String])
+    """
+    Called for each path matching the glob pattern.
+    """


### PR DESCRIPTION
Run pony-lint on PRs that touch .pony files, matching the setup used across other ponylang projects. Fix existing lint issues: file renames to match principal types, missing docstrings, formatting fixes.